### PR TITLE
[Hotfix] - Fix Image Utils

### DIFF
--- a/src/image.cpp
+++ b/src/image.cpp
@@ -25,10 +25,10 @@ namespace jitsuyo
 
 void filter_mat(cv::Mat & src, const cv::Mat & input, uint8_t r, uint8_t g, uint8_t b)
 {
-  for (int row = 0; row < src->rows; row++) {
-    for (int col = 0; col < src->cols; col++) {
+  for (int row = 0; row < src.rows; row++) {
+    for (int col = 0; col < src.cols; col++) {
       if (input.at<uchar>(row, col) > 0) {
-        src->at<cv::Vec3b>(row, col) = cv::Vec3b(b, g, r);
+        src.at<cv::Vec3b>(row, col) = cv::Vec3b(b, g, r);
       }
     }
   }


### PR DESCRIPTION
## Jira Link: 

## Description

There was a build error caused by arrow operator used to access an object in image.cpp. This PR changes it to dot operator.

## Type of Change

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause the existing functionality to not work as expected)

## How Has This Been Tested?

- [ ] New unit tests added.
- [ ] Manual tested.

## Checklist:

- [ ] Using Branch Name Convention
    - `feature/JIRA-ID-SHORT-DESCRIPTION` if has a JIRA ticket
    - `enhancement/SHORT-DESCRIPTION` if has/has no JIRA ticket and contain enhancement
    - `hotfix/SHORT-DESCRIPTION` if the change doesn't need to be tested (urgent)
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made the documentation for the corresponding changes.